### PR TITLE
Implemented `open explorer here`

### DIFF
--- a/launcher/control.py
+++ b/launcher/control.py
@@ -309,7 +309,7 @@ class Controller(QtCore.QObject):
         migrate to another module"""
         # Todo: find a cleaner way, with .toml file for example
 
-        print(">>> Explorer ...")
+        print("Openiing Explorer")
 
         # Get the current environment
         frame = self.current_frame()
@@ -318,7 +318,7 @@ class Controller(QtCore.QObject):
         # When we are outside of any project, do nothing
         config = frame.get("config", None)
         if config is None:
-            print(">>> No project found in configuration")
+            print("No project found in configuration")
             return
 
         template = config['template']['work']
@@ -327,7 +327,7 @@ class Controller(QtCore.QObject):
         # Keep only the part of the path that was formatted
         path = os.path.normpath(path.split("{", 1)[0])
 
-        print(">>>", path)
+        print(path)
         if os.path.exists(path):
             import subprocess
             subprocess.Popen(r'explorer "{}"'.format(path))

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -306,7 +306,7 @@ class Controller(QtCore.QObject):
     @Slot()
     def launch_explorer(self):
         """Initial draft of this method is subject to change and might
-        migrate to"""
+        migrate to another module"""
         # Todo: find a cleaner way, with .toml file for example
 
         print(">>> Explorer ...")
@@ -330,7 +330,7 @@ class Controller(QtCore.QObject):
         print(">>>", path)
         if os.path.exists(path):
             import subprocess
-            subprocess.Popen(r'explorer /select, "{}"'.format(path))
+            subprocess.Popen(r'explorer "{}"'.format(path))
 
     def current_frame(self):
         """Shorthand for the current frame"""

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -147,17 +147,6 @@ class Controller(QtCore.QObject):
         # TODO(marcus): These shouldn't be necessary
         # once the templates are used.
         # ----------------------------------------------------------------------
-        template_rootpath = template_private.split("{silo}")[0]
-        template_assetpath = template_private.split("{asset}")[0] + "{asset}"
-        template_taskpath = template_private.split("{task}")[0] + "{task}"
-
-        silospath = template_rootpath.format(**frame["environment"])
-        assetpath = template_assetpath.format(**frame["environment"])
-        taskpath = template_taskpath.format(**frame["environment"])
-
-        frame["environment"]["silospath"] = silospath
-        frame["environment"]["assetpath"] = assetpath
-        frame["environment"]["taskpath"] = taskpath
         frame["environment"]["workdir"] = workdir
         # ----------------------------------------------------------------------
 
@@ -313,6 +302,35 @@ class Controller(QtCore.QObject):
             thread.start()
 
         return process
+
+    @Slot()
+    def launch_explorer(self):
+        """Initial draft of this method is subject to change and might
+        migrate to"""
+        # Todo: find a cleaner way, with .toml file for example
+
+        print(">>> Explorer ...")
+
+        # Get the current environment
+        frame = self.current_frame()
+        frame["environment"]["root"] = self._root
+
+        # When we are outside of any project, do nothing
+        config = frame.get("config", None)
+        if config is None:
+            print(">>> No project found in configuration")
+            return
+
+        template = config['template']['work']
+        path = lib.partial_format(template, frame["environment"])
+
+        # Keep only the part of the path that was formatted
+        path = os.path.normpath(path.split("{", 1)[0])
+
+        print(">>>", path)
+        if os.path.exists(path):
+            import subprocess
+            subprocess.Popen(r'explorer /select, "{}"'.format(path))
 
     def current_frame(self):
         """Shorthand for the current frame"""

--- a/launcher/lib.py
+++ b/launcher/lib.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import string
 
 from avalon.vendor import six
 from PyQt5 import QtCore
@@ -8,6 +9,11 @@ from PyQt5 import QtCore
 self = sys.modules[__name__]
 self._path = os.path.dirname(__file__)
 self._current_task = None
+
+
+class FormatDict(dict):
+    def __missing__(self, key):
+        return "{" + key + "}"
 
 
 def resource(*path):
@@ -186,3 +192,11 @@ def launch(executable, args=None, environment=None, cwd=None):
 def stream(stream):
     for line in iter(stream.readline, ""):
         yield line
+
+
+def partial_format(s, mapping):
+
+    formatter = string.Formatter()
+    mapping = FormatDict(**mapping)
+
+    return formatter.vformat(s, (), mapping)

--- a/launcher/res/qml/Breadcrumbs.qml
+++ b/launcher/res/qml/Breadcrumbs.qml
@@ -13,7 +13,7 @@ Item {
         ToolButton {
             contentItem: AwesomeIcon {
                 name: "home"
-                size: 20
+                size: 18
             }
 
             height: parent.height

--- a/launcher/res/qml/Breadcrumbs.qml
+++ b/launcher/res/qml/Breadcrumbs.qml
@@ -13,7 +13,7 @@ Item {
         ToolButton {
             contentItem: AwesomeIcon {
                 name: "home"
-                size: 12
+                size: 20
             }
 
             height: parent.height

--- a/launcher/res/qml/main.qml
+++ b/launcher/res/qml/main.qml
@@ -101,7 +101,18 @@ ApplicationWindow {
         }
     }
 
-    footer: MyToolBar { }
+    footer: MyToolBar {
+        MyButton {
+
+            id: launchExplorerButton
+            implicitWidth: parent.height
+            implicitHeight: parent.height
+            icon: "folder-open"
+            Layout.alignment: Qt.AlignLeft
+
+            onClicked: controller.launch_explorer()
+        }
+    }
 
     /** Main Layout
      *  ____________________

--- a/launcher/res/qml/main.qml
+++ b/launcher/res/qml/main.qml
@@ -74,6 +74,21 @@ ApplicationWindow {
                     model: controller.breadcrumbs
                 }
 
+                /** Open explorer in set context based on template
+                 */
+                MyButton {
+
+                    id: launchExplorerButton
+                    implicitWidth: parent.height
+                    implicitHeight: parent.height
+                    icon: "folder-open"
+                    Layout.alignment: Qt.AlignLeft
+
+                    onClicked: controller.launch_explorer()
+
+                    opacity: 0.4
+                }
+
                 /** Toggle Terminal on/off
                  */
                 MyButton {
@@ -101,18 +116,7 @@ ApplicationWindow {
         }
     }
 
-    footer: MyToolBar {
-        MyButton {
-
-            id: launchExplorerButton
-            implicitWidth: parent.height
-            implicitHeight: parent.height
-            icon: "folder-open"
-            Layout.alignment: Qt.AlignLeft
-
-            onClicked: controller.launch_explorer()
-        }
-    }
+    footer: MyToolBar { }
 
     /** Main Layout
      *  ____________________


### PR DESCRIPTION
_Note: Very rudimentary implementation of footer bar launchers._

## Updates
* New lib function for partial formatting of the template
* Add footer button which launches the explorer in the set context (top bar)

The idea is to fill the footer bar with launchers to aid the user to navigate folders without browsing to those folders. This is mainly added to allow artists to move files to task folders. 
One example is to navigate to the lookdev task of an asset in order to add some texture files from the desktop.

## Future
Discover such launchers in a more abstract way such as plugins are discovered in Pyblish
This will need to allow the UI to add buttons to the footer bar. 