### PR TITLE
Implement configuration actions

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,4 +1,0 @@
-from .actions import register_default_actions
-
-# todo(roy): Maybe install studio config instead of "launcher" default
-register_default_actions()

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,21 +1,21 @@
 import sys
 
-from .actions import register_config_actions, register_default_actions
 
 self = sys.modules[__name__]
 self._is_installed = False
 
 
 def install():
-    """Register all actions"""
+    """Register actions"""
 
-    print("Registering actions ..")
+    if self._is_installed:
+        return
+
+    from .actions import register_config_actions, register_default_actions
+
+    print("Registering default actions..")
     register_default_actions()
+    print("Registering config actions..")
     register_config_actions()
 
-    print("Registered actions")
     self._is_installed = True
-
-
-if self._is_installed is False:
-    install()

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,0 +1,21 @@
+import sys
+
+from .actions import register_config_actions, register_default_actions
+
+self = sys.modules[__name__]
+self._is_installed = False
+
+
+def install():
+    """Register all actions"""
+
+    print("Registering actions ..")
+    register_default_actions()
+    register_config_actions()
+
+    print("Registered actions")
+    self._is_installed = True
+
+
+if self._is_installed is False:
+    install()

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -1,5 +1,5 @@
 import avalon.api
-from avalon import lib
+from avalon import pipeline, lib
 
 
 class ProjectManagerAction(avalon.api.Action):
@@ -38,3 +38,15 @@ def register_default_actions():
     """Register default actions for Launcher"""
     avalon.api.register_plugin(avalon.api.Action, ProjectManagerAction)
     avalon.api.register_plugin(avalon.api.Action, LoaderAction)
+
+
+def register_config_actions():
+    """Register actions from the configuration for Launcher"""
+
+    config = pipeline.find_config()
+    if not hasattr(config, "register_launcher_actions"):
+        print("Current configuration `%s` has no 'register_launcher_actions'"
+              % config.__name__)
+        return
+
+    config.register_launcher_actions()

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -11,8 +11,7 @@ class ProjectManagerAction(avalon.api.Action):
     def is_compatible(self, session):
         return "AVALON_PROJECT" in session
 
-    def process(self, session, **kwargs):
-
+    def process(self, session):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.projectmanager",
                                 session['AVALON_PROJECT']])
@@ -27,8 +26,7 @@ class LoaderAction(avalon.api.Action):
     def is_compatible(self, session):
         return "AVALON_PROJECT" in session
 
-    def process(self, session, **kwargs):
-
+    def process(self, session):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.cbloader",
                                 session['AVALON_PROJECT']])

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -1,5 +1,8 @@
+import os
+import importlib
+
 import avalon.api
-from avalon import pipeline, lib
+from avalon import lib
 
 
 class ProjectManagerAction(avalon.api.Action):
@@ -38,10 +41,17 @@ def register_default_actions():
     avalon.api.register_plugin(avalon.api.Action, LoaderAction)
 
 
+def deregister_default_actions():
+    """Remove all actions from default_action from the registry"""
+    avalon.api.deregister_plugin(avalon.api.Action, ProjectManagerAction)
+    avalon.api.deregister_plugin(avalon.api.Action, LoaderAction)
+
+
 def register_config_actions():
     """Register actions from the configuration for Launcher"""
 
-    config = pipeline.find_config()
+    module_name = os.environ["AVALON_CONFIG"]
+    config = importlib.import_module(module_name)
     if not hasattr(config, "register_launcher_actions"):
         print("Current configuration `%s` has no 'register_launcher_actions'"
               % config.__name__)

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -41,12 +41,6 @@ def register_default_actions():
     avalon.api.register_plugin(avalon.api.Action, LoaderAction)
 
 
-def deregister_default_actions():
-    """Remove all actions from default_action from the registry"""
-    avalon.api.deregister_plugin(avalon.api.Action, ProjectManagerAction)
-    avalon.api.deregister_plugin(avalon.api.Action, LoaderAction)
-
-
 def register_config_actions():
     """Register actions from the configuration for Launcher"""
 

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -11,7 +11,7 @@ class ProjectManagerAction(avalon.api.Action):
     def is_compatible(self, session):
         return "AVALON_PROJECT" in session
 
-    def process(self, session):
+    def process(self, session, **kwargs):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.projectmanager",
                                 session['AVALON_PROJECT']])
@@ -26,7 +26,7 @@ class LoaderAction(avalon.api.Action):
     def is_compatible(self, session):
         return "AVALON_PROJECT" in session
 
-    def process(self, session):
+    def process(self, session, **kwargs):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.cbloader",
                                 session['AVALON_PROJECT']])

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -34,7 +34,7 @@ class Application(QtWidgets.QApplication):
             raise  # Server refused to connect
 
         # Install actions
-        actions.register_default_actions()
+        self.register_default_actions()
         actions.register_config_actions()
 
         terminal.init()
@@ -51,6 +51,9 @@ class Application(QtWidgets.QApplication):
         engine.load(QtCore.QUrl.fromLocalFile(source))
 
         self.setQuitOnLastWindowClosed(False)
+
+    def register_default_actions(self):
+        actions.register_default_actions()
 
     def on_object_created(self, object, url):
         if object is None:
@@ -120,6 +123,10 @@ class Application(QtWidgets.QApplication):
         tray.show()
         tray.showMessage("Avalon", "Launcher tray started.",
                          self.windowIcon(), 500)
+
+    def closeEvent(self, event):
+        actions.deregister_default_actions()
+        event.accept()
 
 
 def main(root, demo=False):

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -124,10 +124,6 @@ class Application(QtWidgets.QApplication):
         tray.showMessage("Avalon", "Launcher tray started.",
                          self.windowIcon(), 500)
 
-    def closeEvent(self, event):
-        actions.deregister_default_actions()
-        event.accept()
-
 
 def main(root, demo=False):
     """Start the Qt-runtime and show the window"""

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -34,8 +34,8 @@ class Application(QtWidgets.QApplication):
             raise  # Server refused to connect
 
         # Install actions
-        self.register_default_actions()
-        actions.register_config_actions()
+        from . import install
+        install()
 
         terminal.init()
 
@@ -51,9 +51,6 @@ class Application(QtWidgets.QApplication):
         engine.load(QtCore.QUrl.fromLocalFile(source))
 
         self.setQuitOnLastWindowClosed(False)
-
-    def register_default_actions(self):
-        actions.register_default_actions()
 
     def on_object_created(self, object, url):
         if object is None:

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -10,7 +10,7 @@ import avalon.vendor.qtawesome as qta
 from PyQt5 import QtCore, QtGui, QtQml, QtWidgets, QtQuick
 
 # Local libraries
-from . import control, terminal, lib, actions
+from . import control, terminal, lib
 
 QML_IMPORT_DIR = lib.resource("qml")
 APP_PATH = lib.resource("qml", "main.qml")

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -10,7 +10,7 @@ import avalon.vendor.qtawesome as qta
 from PyQt5 import QtCore, QtGui, QtQml, QtWidgets, QtQuick
 
 # Local libraries
-from . import control, terminal, lib
+from . import control, terminal, lib, actions
 
 QML_IMPORT_DIR = lib.resource("qml")
 APP_PATH = lib.resource("qml", "main.qml")
@@ -32,6 +32,10 @@ class Application(QtWidgets.QApplication):
             io.install()
         except IOError:
             raise  # Server refused to connect
+
+        # Install actions
+        actions.register_default_actions()
+        actions.register_config_actions()
 
         terminal.init()
 

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -199,28 +199,7 @@ class Controller(QtCore.QObject):
         handler(index)
 
         # Push the compatible applications
-        actions = []
-        for Action in self._registered_actions:
-            frame = self.current_frame()
-
-            # Build a session from current frame
-            session = {"AVALON_{}".format(key.upper()): value for
-                        key, value in frame.get("environment", {}).items()}
-            session["AVALON_PROJECTS"] = api.registered_root()
-            if not Action().is_compatible(session):
-                continue
-
-            actions.append({
-                "name": str(Action.name),
-                "icon": str(Action.icon or "cube"),
-                "label": str(Action.label or Action.name),
-                "color": getattr(Action, "color", None),
-                "order": Action.order
-            })
-
-        # Sort by order and name
-        actions = sorted(actions, key=lambda action: (action["order"],
-                                                      action["name"]))
+        actions = self.collect_compatible_actions(self._registered_actions)
         self._actions.push(actions)
 
         self.navigated.emit()
@@ -267,18 +246,15 @@ class Controller(QtCore.QObject):
                 "name": project["name"],
             }, **project["data"])
             for project in sorted(io.projects(), key=lambda x: x['name'])
-
-            # Discard hidden projects
-            if project["data"].get("visible", True)
+            if project["data"].get("visible", True)  # Discard hidden projects
         ])
 
-        # No actions outside of projects
-        self._actions.push([])
-
-        frame = {
-            "environment": {},
-        }
+        frame = {"environment": {}}
         self._frames[:] = [frame]
+
+        # Validate actions based on compatibility
+        actions = self.collect_compatible_actions(api.discover(api.Action))
+        self._actions.push(actions)
 
         self.pushed.emit(header)
         self.navigated.emit()
@@ -301,8 +277,7 @@ class Controller(QtCore.QObject):
         # Get available project actions and the application actions
         actions = api.discover(api.Action)
         apps = lib.get_apps(project)
-        actions.extend(apps)
-        self._registered_actions[:] = actions
+        self._registered_actions[:] = actions + apps
 
         silos = io.distinct("silo")
         self._model.push([
@@ -469,6 +444,44 @@ class Controller(QtCore.QObject):
 
     def log(self, message, level=DEBUG):
         print(message)
+
+    def collect_compatible_actions(self, actions):
+        """Collect all actions which are compatible with the environment
+
+        Each compatible action will be translated to a dictionary to ensure
+        the action can be visualized in the launcher.
+
+        Args:
+            actions (list): list of classes
+
+        Returns:
+            list: collection of dictionaries sorted on order int he
+        """
+
+        compatible = []
+        for Action in actions:
+            frame = self.current_frame()
+
+            # Build a session from current frame
+            session = {"AVALON_{}".format(key.upper()): value for
+                       key, value in frame.get("environment", {}).items()}
+            session["AVALON_PROJECTS"] = api.registered_root()
+            if not Action().is_compatible(session):
+                continue
+
+            compatible.append({
+                "name": str(Action.name),
+                "icon": str(Action.icon or "cube"),
+                "label": str(Action.label or Action.name),
+                "color": getattr(Action, "color", None),
+                "order": Action.order
+            })
+
+        # Sort by order and name
+        compatible = sorted(compatible, key=lambda action: (action["order"],
+                                                            action["name"]))
+
+        return compatible
 
 
 def dirs(root):

--- a/launcher/lib.py
+++ b/launcher/lib.py
@@ -47,7 +47,14 @@ def stream(stream):
 
 
 def get_apps(project):
-    """Define dynamic Application classes for project using `.toml` files"""
+    """Define dynamic Application classes for project using `.toml` files
+
+    Args:
+        project (dict): project document from the database
+
+    Returns:
+        list: list of dictionaries
+    """
 
     import avalon.lib
     import avalon.api as api


### PR DESCRIPTION
Introduces the ability to register actions from configuration

* Check if config has `register_launcher_actions` attribute 
  * Run if found
* Allow show actions at start of launcher