### PR TITLE
Add config flag to LoaderAction

### DIFF
--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -1,11 +1,10 @@
 import os
 import importlib
 
-import avalon.api
-from avalon import lib
+from avalon import api, lib
 
 
-class ProjectManagerAction(avalon.api.Action):
+class ProjectManagerAction(api.Action):
     name = "projectmanager"
     label = "Project Manager"
     icon = "gear"
@@ -20,7 +19,7 @@ class ProjectManagerAction(avalon.api.Action):
                                 session['AVALON_PROJECT']])
 
 
-class LoaderAction(avalon.api.Action):
+class LoaderAction(api.Action):
     name = "loader"
     label = "Loader"
     icon = "cloud-download"
@@ -38,8 +37,8 @@ class LoaderAction(avalon.api.Action):
 
 def register_default_actions():
     """Register default actions for Launcher"""
-    avalon.api.register_plugin(avalon.api.Action, ProjectManagerAction)
-    avalon.api.register_plugin(avalon.api.Action, LoaderAction)
+    api.register_plugin(api.Action, ProjectManagerAction)
+    api.register_plugin(api.Action, LoaderAction)
 
 
 def register_config_actions():

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -32,7 +32,8 @@ class LoaderAction(avalon.api.Action):
     def process(self, session, **kwargs):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.cbloader",
-                                session['AVALON_PROJECT']])
+                                "-project", session['AVALON_PROJECT'],
+                                "-config", session.get("AVALON_CONFIG", "")])
 
 
 def register_default_actions():

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -31,8 +31,7 @@ class LoaderAction(api.Action):
     def process(self, session, **kwargs):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.cbloader",
-                                "-project", session['AVALON_PROJECT'],
-                                "-config", session.get("AVALON_CONFIG", "")])
+                                "project", session['AVALON_PROJECT']])
 
 
 def register_default_actions():

--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -31,7 +31,7 @@ class LoaderAction(api.Action):
     def process(self, session, **kwargs):
         return lib.launch(executable="python",
                           args=["-u", "-m", "avalon.tools.cbloader",
-                                "project", session['AVALON_PROJECT']])
+                                session['AVALON_PROJECT']])
 
 
 def register_default_actions():


### PR DESCRIPTION
_Resolves issue PLN-105_

This is one part of a multiple PRs to resolve the issue with the configuration not being installed in a standalone state.

It is being resolved by allowing the user to pass `-config` as an argument for an app, in this case the Loader.
This will trigger the `pipeline.find_config` and `config.install` which will result in registered plugins when launching the app standalone.

This allows us to create Loaders which might be useful outside of a host such as `copy file path`